### PR TITLE
Add option to list modules in export codegen

### DIFF
--- a/natrix/__init__.py
+++ b/natrix/__init__.py
@@ -259,6 +259,11 @@ def parse_args() -> argparse.Namespace:
             "(e.g., -p /path/to/libs /another/path)."
         ),
     )
+    exports_parser.add_argument(
+        "--display-modules",
+        action="store_true",
+        help="Include comments showing which module functions come from",
+    )
 
     # Create the call_graph sub-subcommand
     call_graph_parser = codegen_subparsers.add_parser(
@@ -303,7 +308,11 @@ def main() -> None:
             # Get extra paths if provided
             extra_paths = tuple(Path(p) for p in args.path) if args.path else ()
             # Generate and print exports
-            exports = generate_exports(Path(args.file_path), extra_paths)
+            exports = generate_exports(
+                Path(args.file_path),
+                extra_paths,
+                include_module_comments=args.display_modules,
+            )
             print(exports)
             sys.exit(0)
         elif args.codegen_command == "call_graph":

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -29,3 +29,43 @@ exports: (
     version_dummy.view_external_marked_as_nothing
 )"""
     assert result.stdout.strip() == expected
+
+
+def test_codegen_exports_with_module_comments():
+    """Test the codegen exports command with module comments enabled."""
+    # Use the scrvusd_oracle contract which imports from ownable
+    test_contract = (
+        Path(__file__).parent / "contracts" / "scrvusd_oracle" / "scrvusd_oracle.vy"
+    )
+
+    # Run the codegen exports command with --display-modules flag
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "natrix",
+            "codegen",
+            "exports",
+            str(test_contract),
+            "--display-modules",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # Check that the command succeeded
+    assert result.returncode == 0
+
+    output = result.stdout.strip()
+
+    # Should contain the exports section
+    assert "exports: (" in output
+
+    # Should contain functions from ownable module with comments
+    assert "owner,  # ownable" in output
+    assert "transfer_ownership,  # ownable" in output
+    assert "renounce_ownership,  # ownable" in output
+
+    # Should contain functions from main contract without comments
+    assert "scrvusd_oracle.price_v0," in output
+    assert "scrvusd_oracle.update_price," in output


### PR DESCRIPTION
When trying to move from importing `__interface__` to explicit imports, if a contract relies on a lot of module, it can be unclear what function is coming from an underlying module and what is defined in the contract. This PR adds an argument to `codegen exports` so that if an exported function is coming from a module, the module's name will be displayed as a comment next to it.

For instance in the scrvusd_oracle contract in the tests:

`> natrix codegen exports tests/contracts/scrvusd_oracle/scrvusd_oracle.vy --display-modules`

```
# NOTE: Always double-check the generated exports
exports: (
    scrvusd_oracle.max_acceleration,
    scrvusd_oracle.owner,  # ownable
    scrvusd_oracle.price_v0,
    scrvusd_oracle.price_v1,
    scrvusd_oracle.prover,
    scrvusd_oracle.raw_price,
    scrvusd_oracle.renounce_ownership,  # ownable
    scrvusd_oracle.set_max_acceleration,
    scrvusd_oracle.set_prover,
    scrvusd_oracle.transfer_ownership,  # ownable
    scrvusd_oracle.update_price,
    scrvusd_oracle.version
)
```